### PR TITLE
#6 Version independence: JDK version is not part of the image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-# jdk9-ocamorph-pyphen
+# jdk-ocamorph-pyphen
 
-[![Build Status](https://travis-ci.org/szgabsz91/jdk9-ocamorph-pyphen.svg?branch=master)](https://travis-ci.org/szgabsz91/jdk9-ocamorph-pyphen)
+[![Build Status](https://travis-ci.org/szgabsz91/jdk-ocamorph-pyphen.svg?branch=master)](https://travis-ci.org/szgabsz91/jdk-ocamorph-pyphen)
 
-Docker image that contains JDK9, Ocamorph and Pyphen.
+Docker image that contains JDK, Ocamorph and Pyphen.
+
+The latest version is 9.0.0 that supports JDK9.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-docker build -t jdk9-ocamorph-pyphen ./src
-docker build -t jdk9-ocamorph-pyphen-test ./test
+docker build -t jdk-ocamorph-pyphen ./src
+docker build -t jdk-ocamorph-pyphen-test ./test

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -3,8 +3,8 @@
 function publish() {
     echo "Publishing for version $1"
     docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
-    docker tag jdk9-ocamorph-pyphen szgabsz91/jdk9-ocamorph-pyphen:$1
-    docker push szgabsz91/jdk9-ocamorph-pyphen:$1
+    docker tag jdk-ocamorph-pyphen szgabsz91/jdk-ocamorph-pyphen:$1
+    docker push szgabsz91/jdk-ocamorph-pyphen:$1
 }
 
 BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-${TRAVIS_BRANCH}}
@@ -17,7 +17,7 @@ if [[ $BRANCH == "master" ]];
 then
     # master branch - latest version
     publish "latest"
-elif [[ $BRANCH =~ ^jdk9-ocamorph-pyphen-.* ]];
+elif [[ $BRANCH =~ ^jdk-ocamorph-pyphen-.* ]];
 then
     # tag - cut version from the tag
     publish $(echo $BRANCH | cut -d '-' -f 4)

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-docker run -t jdk9-ocamorph-pyphen-test
+docker run -t jdk-ocamorph-pyphen-test

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM jdk9-ocamorph-pyphen
+FROM jdk-ocamorph-pyphen
 
 ADD ./verify.sh /verify.sh
 RUN chmod +x /verify.sh


### PR DESCRIPTION
`jdk-ocamorph-pyphen:9.0.0` supports JDK9.